### PR TITLE
CSM-12653: Add org account access role config

### DIFF
--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -27,7 +27,8 @@ Role Group resource
 - `upt_account_id` (String) Uptycs AWS account ID
 
 ### Optional
-- `org_access_role_name` (String) Org account access IAM role name
+
+- `org_access_role_name` (String) Organization Account Access Role Name
 
 ### Read-Only
 

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -26,6 +26,9 @@ Role Group resource
 - `profile_name` (String) Profile name
 - `upt_account_id` (String) Uptycs AWS account ID
 
+### Optional
+- `org_access_role_name` (String) Org account access IAM role name
+
 ### Read-Only
 
 - `role` (String) Role ARN

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -72,6 +72,11 @@ func (t roleResourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Dia
 				Required:            true,
 				Type:                types.StringType,
 			},
+			"org_access_role_name": {
+				MarkdownDescription: "Organization Account Access Role Name",
+				Optional:            true,
+				Type:                types.StringType,
+			},
 		},
 	}, nil
 }
@@ -86,15 +91,16 @@ func (t roleResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (t
 }
 
 type exampleResourceData struct {
-	ProfileName     types.String `tfsdk:"profile_name"`
-	AccountID       types.String `tfsdk:"account_id"`
-	IntegrationName types.String `tfsdk:"integration_name"`
-	UptAccountID    types.String `tfsdk:"upt_account_id"`
-	ExternalID      types.String `tfsdk:"external_id"`
-	Role            types.String `tfsdk:"role"`
-	BucketName      types.String `tfsdk:"bucket_name"`
-	BucketRegion    types.String `tfsdk:"bucket_region"`
-	PolicyDocument  types.String `tfsdk:"policy_document"`
+	ProfileName       types.String `tfsdk:"profile_name"`
+	AccountID         types.String `tfsdk:"account_id"`
+	IntegrationName   types.String `tfsdk:"integration_name"`
+	UptAccountID      types.String `tfsdk:"upt_account_id"`
+	ExternalID        types.String `tfsdk:"external_id"`
+	Role              types.String `tfsdk:"role"`
+	BucketName        types.String `tfsdk:"bucket_name"`
+	BucketRegion      types.String `tfsdk:"bucket_region"`
+	PolicyDocument    types.String `tfsdk:"policy_document"`
+	OrgAccessRoleName types.String `tfsdk:"org_access_role_name"`
 }
 
 type roleResource struct {
@@ -121,7 +127,7 @@ func (r roleResource) Create(ctx context.Context, req tfsdk.CreateResourceReques
 
 	// For the purposes of this example code, hardcoding a response value to
 	// save into the Terraform state.
-	svc, errSvc := awsinternal.GetAwsIamClient(ctx, data.ProfileName.Value, "aws-global", data.AccountID.Value)
+	svc, errSvc := awsinternal.GetAwsIamClient(ctx, data.ProfileName.Value, "aws-global", data.AccountID.Value, data.OrgAccessRoleName.Value)
 	if errSvc != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get client for %s with profile %s. err=%s", data.AccountID.Value, data.ProfileName.Value, errSvc.Error()))
 		return
@@ -136,6 +142,7 @@ func (r roleResource) Create(ctx context.Context, req tfsdk.CreateResourceReques
 		data.ProfileName.Value,
 		data.AccountID.Value,
 		data.PolicyDocument.Value,
+		data.OrgAccessRoleName.Value,
 		false)
 	if errCreate != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create uptycscspm role. err=%s", errCreate))
@@ -169,7 +176,7 @@ func (r roleResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, r
 	//     resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read example, got error: %s", err))
 	//     return
 	// }
-	svc, errSvc := awsinternal.GetAwsIamClient(ctx, data.ProfileName.Value, "aws-global", data.AccountID.Value)
+	svc, errSvc := awsinternal.GetAwsIamClient(ctx, data.ProfileName.Value, "aws-global", data.AccountID.Value, data.OrgAccessRoleName.Value)
 	if errSvc != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get client for %s with profile %s. err=%s", data.AccountID.Value, data.ProfileName.Value, errSvc.Error()))
 		return
@@ -202,7 +209,7 @@ func (r roleResource) Update(ctx context.Context, req tfsdk.UpdateResourceReques
 	//     resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update example, got error: %s", err))
 	//     return
 	// }
-	svc, errSvc := awsinternal.GetAwsIamClient(ctx, data.ProfileName.Value, "aws-global", data.AccountID.Value)
+	svc, errSvc := awsinternal.GetAwsIamClient(ctx, data.ProfileName.Value, "aws-global", data.AccountID.Value, data.OrgAccessRoleName.Value)
 	if errSvc != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get client for %s with profile %s. err=%s", data.AccountID.Value, data.ProfileName.Value, errSvc.Error()))
 		return
@@ -222,6 +229,7 @@ func (r roleResource) Update(ctx context.Context, req tfsdk.UpdateResourceReques
 		data.ProfileName.Value,
 		data.AccountID.Value,
 		data.PolicyDocument.Value,
+		data.OrgAccessRoleName.Value,
 		true)
 	if errCreate != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to re-create uptycscspm role. err=%s", errCreate))
@@ -249,7 +257,7 @@ func (r roleResource) Delete(ctx context.Context, req tfsdk.DeleteResourceReques
 	//     resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete example, got error: %s", err))
 	//     return
 	// }
-	svc, errSvc := awsinternal.GetAwsIamClient(ctx, data.ProfileName.Value, "aws-global", data.AccountID.Value)
+	svc, errSvc := awsinternal.GetAwsIamClient(ctx, data.ProfileName.Value, "aws-global", data.AccountID.Value, data.OrgAccessRoleName.Value)
 	if errSvc != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get client for %s with profile %s. err=%s", data.AccountID.Value, data.ProfileName.Value, errSvc.Error()))
 		return

--- a/internal/provider/role_resource_test.go
+++ b/internal/provider/role_resource_test.go
@@ -17,7 +17,7 @@ func TestAccRoleResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccRoleResourceConfig("noprofile", "123456789012", "012345678912", "uptcloud", "6a9375c1-47c0-470c-9217-d2f9d2d185f1", "uptycs-test-bucket", "us-east-1", ""),
+				Config: testAccRoleResourceConfig("noprofile", "123456789012", "012345678912", "uptcloud", "6a9375c1-47c0-470c-9217-d2f9d2d185f1", "uptycs-test-bucket", "us-east-1", "", "OrganizationAccountAccessRole"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("uptycscspm_role.test", "profile_name", "noprofile"),
 					resource.TestCheckResourceAttr("uptycscspm_role.test", "account_id", "123456789012"),
@@ -28,6 +28,7 @@ func TestAccRoleResource(t *testing.T) {
 					resource.TestCheckResourceAttr("uptycscspm_role.test", "bucket_name", "uptycs-test-bucket"),
 					resource.TestCheckResourceAttr("uptycscspm_role.test", "bucket_region", "us-east-1"),
 					resource.TestCheckResourceAttr("uptycscspm_role.test", "policy_document", ""),
+					resource.TestCheckResourceAttr("uptycscspm_role.test", "org_access_role_name", "OrganizationAccountAccessRole"),
 				),
 				// Expect to fail as we cannot contact AWS with fake accounts
 				ExpectError: errRegex,
@@ -60,7 +61,7 @@ func TestAccRoleResource(t *testing.T) {
 	})
 }
 
-func testAccRoleResourceConfig(profile string, account string, uptAccount string, integration string, externalID string, bucketName string, bucketRegion string, policyDocument string) string {
+func testAccRoleResourceConfig(profile string, account string, uptAccount string, integration string, externalID string, bucketName string, bucketRegion string, policyDocument string, orgAccessRoleName string) string {
 	return fmt.Sprintf(`
 resource "uptycscspm_role" "test" {
   profile_name = %[1]q
@@ -71,7 +72,8 @@ resource "uptycscspm_role" "test" {
   bucket_name = %[6]q
   bucket_region = %[7]q
   policy_document = %[8]q
+  org_access_role_name = %[9]q
 
 }
-`, profile, account, uptAccount, integration, externalID, bucketName, bucketRegion, policyDocument)
+`, profile, account, uptAccount, integration, externalID, bucketName, bucketRegion, policyDocument, orgAccessRoleName)
 }


### PR DESCRIPTION
In ControlTower Organisation, the cross account access role giving admin rights to child account is different than normal organisation. Having this as an optional parameter will allow the role to be assumed while creating cspm resources configurable. The changes are backward compatible with existing terraform using this module as the added org_access_role_name is optional. If it is not passed we will assume OrganizationAccountAccessRole in child accounts to create resources otherwise will use the one that has been passed.

Tested below scenarios -
Successfully ran existing terraform with local build with these changes
1) Without passing org_access_role_name [pass]
2) Passing valid org_access_role_name [pass]
3) Passing invalid org_access_role_name [fail, Assume role permission error in terraform]
4) Ran Terraform Apply / Delete for CSPM resources. Resources got successfully created / deleted in child accounts 

This needs to be tested in Control Tower environment as well. It will work if org_access_role_name is passed and the value is AWSControlTowerExecution. The tests were done to check if the module is assuming whatever role we are passing, which it does. In separate testing AWSControlTowerExecution is found to have same rights as that of OrganizationAccountAccessRole and we can create resources in child account from master account by assuming this role